### PR TITLE
change the command run method

### DIFF
--- a/tasks/grunt-htmlcompressor.js
+++ b/tasks/grunt-htmlcompressor.js
@@ -7,6 +7,7 @@
  */
 
 /*global _:true, __dirname */
+var exec = require('child_process').exec;
 
 module.exports = function(grunt) {
   'use strict';
@@ -31,22 +32,22 @@ module.exports = function(grunt) {
 
       async.forEach(srcFiles, function(srcFile, nextF) {
 
-        var args = _.flatten(['-jar', jar, _.map(options, toParameter), srcFile]);
-
-        grunt.util.spawn({
-          cmd: 'java',
-          args: args
-        }, function(err, output, code) {
+        var args = _.flatten(['java', '-jar', jar, _.map(options, toParameter), srcFile]);
+        var dest = _.isFunction(processName) ?
+          processName(srcFile, html) : file.dest;
+        args.push('>');
+        args.push(dest);
+        exec(args.join(' '), function(err, output, code) {
           if (err) {
             grunt.log.error();
             grunt.verbose.error(err);
             grunt.fail.warn('htmlcompressor failed to compress html.');
             nextF(err);
           } else {
-            var html = output.stdout;
-            var dest = _.isFunction(processName) ?
-              processName(srcFile, html) : file.dest;
-            grunt.file.write(dest, html);
+            // var html = output.stdout;
+            // var dest = _.isFunction(processName) ?
+            //   processName(srcFile, html) : file.dest;
+            // grunt.file.write(dest, html);
             grunt.log.writeln('File "' + dest + '" created.');
             nextF();
           }


### PR DESCRIPTION
If you want to compress a file that not use ut8 encoding,you will get a garbled file.Because node's default charset is utf8,and don't support most encodings such as gbk and gb2312.So I use 'I/O Redirection' to archive this.
